### PR TITLE
Wip/images of text

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -37,6 +37,7 @@ import { TextsPageComponent } from './components/texts-page/texts-page.component
 import { TextPageComponent } from './components/text-page/text-page.component';
 import { NotFoundComponent } from './components/not-found/not-found.component';
 import { FormsModule } from '@angular/forms';
+import { PageLinkDirective } from './directives/page-link.directive';
 
 export function initializeApp(appInitService: AppInitService) {
   return (): Promise<any> => {
@@ -63,7 +64,8 @@ export function initializeApp(appInitService: AppInitService) {
     TextsPageComponent,
     TextPageComponent,
     NotFoundComponent,
-    EncodeURIComponentPipe
+    EncodeURIComponentPipe,
+    PageLinkDirective
   ],
   imports: [
     KuiCoreModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,6 +36,7 @@ import { TextViewComponent } from './components/text-view/text-view.component';
 import { TextsPageComponent } from './components/texts-page/texts-page.component';
 import { TextPageComponent } from './components/text-page/text-page.component';
 import { NotFoundComponent } from './components/not-found/not-found.component';
+import { FormsModule } from '@angular/forms';
 
 export function initializeApp(appInitService: AppInitService) {
   return (): Promise<any> => {
@@ -71,6 +72,7 @@ export function initializeApp(appInitService: AppInitService) {
     KuiSearchModule,
     AppRoutingModule,
     HttpClientModule,
+    FormsModule,
     TranslateModule.forRoot({
       loader: {
         provide: TranslateLoader,

--- a/src/app/components/fulltext-search/fulltext-search.component.html
+++ b/src/app/components/fulltext-search/fulltext-search.component.html
@@ -4,7 +4,7 @@
 <router-outlet></router-outlet> -->
 
 <div class="container">
-  <input style="width: 300px;" type="text" #searchInput />
+  <input style="width: 300px;" type="text" #searchInput />  <!-- # indicate variable -->
   <button (click)="onSearch(searchInput.value)">Search</button>
 </div>
 

--- a/src/app/components/fulltext-search/fulltext-search.component.ts
+++ b/src/app/components/fulltext-search/fulltext-search.component.ts
@@ -14,7 +14,7 @@ export class FulltextSearchComponent implements OnInit {
   ngOnInit() {}
 
   onSearch(searchText: string) {
-    if (searchText && searchText.length > 0) {
+    if (searchText && searchText.length > 0) {  // check is not empty
       this.dataService.fullTextSearch(searchText).subscribe(
         (resources: Resource[]) => {
           this.resources = resources;

--- a/src/app/components/text-page/text-page.component.html
+++ b/src/app/components/text-page/text-page.component.html
@@ -1,12 +1,37 @@
 <h1><div [innerHTML]="text?.title | htmlSanitizer"></div></h1>
 
-<or-text-view [text]="text"></or-text-view>
-<!--this will be given to the @input-->
-
-<!-- add list of IRI of facsimile in a test component somethign like 'list of images' -->
-
-<ul>
-    <li *ngFor="let page of pages" >
-        {{page.imageURL}}
-    </li>
-</ul>
+<div class="container">
+  <div class="row">
+    <div class="col-sm">
+      <or-text-view [text]="text"></or-text-view>
+      <!--this will be given to the @input-->
+    </div>
+    <div class="col-sm">
+      <select
+        class="form-control"
+        name="page-numbers"
+        [(ngModel)]="selectedPageNum"
+      >
+        <option></option>
+        <option [value]="page.seqnum" *ngFor="let page of pages">
+          Page {{ page.seqnum }}</option
+        >
+      </select>
+      <div *ngFor="let page of pages">
+        <img
+          *ngIf="page.seqnum === selectedPageNum"
+          src="{{ page.imageURL }}"
+          width="400"
+          height="400"
+        />
+      </div>
+      <!-- add list of IRI of facsimile in a test component somethign like 'list of images' -->
+      <!-- <ul>
+        <li *ngFor="let page of pages">
+          {{ page.seqnum }}
+          <img src="{{ page.imageURL }}" width="50" height="50" />
+        </li>
+      </ul> -->
+    </div>
+  </div>
+</div>

--- a/src/app/components/text-page/text-page.component.html
+++ b/src/app/components/text-page/text-page.component.html
@@ -4,3 +4,9 @@
 <!--this will be given to the @input-->
 
 <!-- add list of IRI of facsimile in a test component somethign like 'list of images' -->
+
+<ul>
+    <li *ngFor="let page of pages" >
+        {{page.imageURL}}
+    </li>
+</ul>

--- a/src/app/components/text-page/text-page.component.html
+++ b/src/app/components/text-page/text-page.component.html
@@ -1,11 +1,18 @@
 <h1><div [innerHTML]="text?.title | htmlSanitizer"></div></h1>
 
 <div class="container">
+
   <div class="row">
-    <div class="col-sm">
-      <or-text-view [text]="text"></or-text-view>
+    
+    <div class="col-sm container-scrollable">
+      <or-text-view
+        [text]="text"
+        orPageLink
+        [(pageNum)]="selectedPageNum"
+      ></or-text-view>
       <!--this will be given to the @input-->
     </div>
+
     <div class="col-sm">
       <select
         class="form-control"
@@ -33,5 +40,6 @@
         </li>
       </ul> -->
     </div>
+    
   </div>
 </div>

--- a/src/app/components/text-page/text-page.component.scss
+++ b/src/app/components/text-page/text-page.component.scss
@@ -1,0 +1,4 @@
+.container-scrollable {
+  overflow-y: scroll;
+  height: 400px;
+}

--- a/src/app/components/text-page/text-page.component.ts
+++ b/src/app/components/text-page/text-page.component.ts
@@ -12,6 +12,7 @@ import { DataService } from 'src/app/services/data.service';
 export class TextPageComponent implements OnInit {
   text: Text;
   pages: Page[];
+  selectedPageNum: null;
 
   constructor(
     private route: ActivatedRoute, // it gives me the current route (URL)
@@ -31,14 +32,13 @@ export class TextPageComponent implements OnInit {
           .subscribe(
             (text: Text) => {
               this.text = text; // step 4    I give to the attribute text the value of text
-              
 
-          // asynchrone, we need text to ask pages of text
-              this.dataService.getPagesOfText(text.id).subscribe(
-                    (pages: Page[]) => {
-                      this.pages = pages;
-                    }
-              );
+              // asynchrone, we need text to ask pages of text
+              this.dataService
+                .getPagesOfText(text.id)
+                .subscribe((pages: Page[]) => {
+                  this.pages = pages;
+                });
             },
             error => console.error(error)
           );

--- a/src/app/components/text-page/text-page.component.ts
+++ b/src/app/components/text-page/text-page.component.ts
@@ -12,7 +12,7 @@ import { DataService } from 'src/app/services/data.service';
 export class TextPageComponent implements OnInit {
   text: Text;
   pages: Page[];
-  selectedPageNum: null;
+  selectedPageNum: null;  //give here a default value is not enough to visualize page, it doesn't take the page.imageURL
 
   constructor(
     private route: ActivatedRoute, // it gives me the current route (URL)

--- a/src/app/components/text-page/text-page.component.ts
+++ b/src/app/components/text-page/text-page.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { Text } from 'src/app/models/text.model';
+import { Page } from 'src/app/models/page.model';
 import { ActivatedRoute } from '@angular/router';
 import { DataService } from 'src/app/services/data.service';
 
@@ -10,6 +11,7 @@ import { DataService } from 'src/app/services/data.service';
 })
 export class TextPageComponent implements OnInit {
   text: Text;
+  pages: Page[];
 
   constructor(
     private route: ActivatedRoute, // it gives me the current route (URL)
@@ -29,6 +31,14 @@ export class TextPageComponent implements OnInit {
           .subscribe(
             (text: Text) => {
               this.text = text; // step 4    I give to the attribute text the value of text
+              
+
+          // asynchrone, we need text to ask pages of text
+              this.dataService.getPagesOfText(text.id).subscribe(
+                    (pages: Page[]) => {
+                      this.pages = pages;
+                    }
+              );
             },
             error => console.error(error)
           );

--- a/src/app/components/text-view/text-view.component.html
+++ b/src/app/components/text-view/text-view.component.html
@@ -1,1 +1,1 @@
-<div [innerHtml]="text?.establishedText | htmlSanitizer"></div>
+<div [innerHtml]="text?.establishedText | htmlSanitizer" orResourceLink></div>

--- a/src/app/directives/page-link.directive.ts
+++ b/src/app/directives/page-link.directive.ts
@@ -1,0 +1,50 @@
+import {
+  Directive,
+  ElementRef,
+  Renderer2,
+  AfterViewInit,
+  DoCheck,
+  OnInit,
+  Input,
+  EventEmitter,
+  Output
+} from '@angular/core';
+import { Router } from '@angular/router';
+
+@Directive({
+  selector: '[orPageLink]'
+})
+export class PageLinkDirective implements DoCheck {
+  @Output()
+  pageNumChange = new EventEmitter<string>();
+
+  @Input()
+  set pageNum(pageNum: string) {
+    if (pageNum) {
+      console.log('try to scroll to page ' + pageNum);
+      this.el.nativeElement
+        .querySelectorAll('a[class="pageLink"]')
+        .forEach((aElt: HTMLElement) => {
+          if (aElt.attributes['href'].value === pageNum) {
+            console.log('Found page, scroll to ' + pageNum);
+            aElt.scrollIntoView();
+          }
+        });
+    }
+  }
+
+  constructor(private el: ElementRef) {}
+
+  onClick(event) {
+    const page = event.target.attributes['href'].value;
+    console.log('open page ' + page);
+    this.pageNumChange.next(page);
+    event.preventDefault();
+  }
+
+  ngDoCheck(): void {
+    this.el.nativeElement.querySelectorAll('a').forEach((aElt: HTMLElement) => {
+      aElt.addEventListener('click', this.onClick.bind(this));
+    });
+  }
+}

--- a/src/app/directives/resource-link.directive.ts
+++ b/src/app/directives/resource-link.directive.ts
@@ -24,8 +24,9 @@ export class ResourceLinkDirective implements DoCheck {
 }
 
 reRouteLink(el: ElementRef) {
-  el.nativeElement.querySelectorAll('a').forEach((aElt: HTMLElement) => {
-    // TODO: check that href contains IRI, because this is applied to all 'a'
+  
+  el.nativeElement.querySelectorAll('a[class="resourceLink"]').forEach((aElt: HTMLElement) => {
+    // gives back an array of <a class="resourceLink">
     aElt.addEventListener('click', this.onClick.bind(this));
   });
 }

--- a/src/app/models/page.model.ts
+++ b/src/app/models/page.model.ts
@@ -1,0 +1,6 @@
+import { Resource } from './resource.model';
+
+export interface Page extends Resource {
+    seqnum: string;
+    imageURL: string;
+}

--- a/src/app/models/person.model.spec.ts
+++ b/src/app/models/person.model.spec.ts
@@ -1,7 +1,0 @@
-import { Person.Model } from './person.model';
-
-describe('Person.Model', () => {
-  it('should create an instance', () => {
-    expect(new Person.Model()).toBeTruthy();
-  });
-});

--- a/src/app/models/person.model.ts
+++ b/src/app/models/person.model.ts
@@ -7,7 +7,7 @@ import {
   KuiConfig
 } from '@knora/core';
 
-export interface PersonLight extends Resource {
+export interface PersonLight extends Resource {  //pour construire une personne
   surname: string;
   name: string;
 }

--- a/src/app/models/resource.model.spec.ts
+++ b/src/app/models/resource.model.spec.ts
@@ -1,7 +1,0 @@
-import { Resource.Model } from './resource.model';
-
-describe('Resource.Model', () => {
-  it('should create an instance', () => {
-    expect(new Resource.Model()).toBeTruthy();
-  });
-});

--- a/src/app/models/text.model.spec.ts
+++ b/src/app/models/text.model.spec.ts
@@ -1,7 +1,0 @@
-import { Text.Model } from './text.model';
-
-describe('Text.Model', () => {
-  it('should create an instance', () => {
-    expect(new Text.Model()).toBeTruthy();
-  });
-});

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -59,6 +59,7 @@ CONSTRUCT {
   ?fac roud-oeuvres:hasSeqnum ?seqnum .
   ?fac knora-api:hasStillImageFileValue ?imageURL .
 }
+ORDER BY ?seqnum
 OFFSET ${index}
 `
 ;

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -31,7 +31,7 @@ export class DataService {
     return `${this.kuiConfig.knora.apiProtocol}://${this.kuiConfig.knora.apiHost}:${this.kuiConfig.knora.apiPort}/ontology/0112/roud-oeuvres/v2#`;
   }
 
-  fullTextSearch(searchText: string, offset = 0): Observable<Resource[]> {
+  fullTextSearch(searchText: string, offset = 0): Observable<Resource[]> {   //offset = 0, only first page
     return this.knoraApiConnection.v2.search
       .doFulltextSearch(searchText, offset, {
         limitToProject: this.getProjectIRI()

--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -5,6 +5,8 @@ import { map } from 'rxjs/operators';
 import { Person, PersonLight } from '../models/person.model';
 import { Resource } from '../models/resource.model';
 import { Text, TextLight } from '../models/text.model';
+import { Page } from '../models/page.model';
+
 import {
   KnoraApiConnectionToken,
   KuiConfigToken,
@@ -40,6 +42,38 @@ export class DataService {
         ) => readResources.map(r => this.readRes2Resource(r)))
       );
   }
+
+
+  getPagesOfText(textIRI: string, index: number = 0): Observable<Page[]> {  //Observable va retourner table of Pages
+    const gravsearchQuery = `
+PREFIX knora-api: <http://api.knora.org/ontology/knora-api/v2#>
+PREFIX roud-oeuvres: <${this.getOntoPrefixPath()}>
+CONSTRUCT {
+  ?fac knora-api:isMainResource true .
+  ?fac roud-oeuvres:hasSeqnum ?seqnum .
+  ?fac knora-api:hasStillImageFileValue ?imageURL .
+} WHERE {
+  ?fac a roud-oeuvres:Page .
+  ?fac roud-oeuvres:pageIsPartOfManuscript ?man .
+  <${textIRI}> roud-oeuvres:hasDirectSourceManuscript ?man .
+  ?fac roud-oeuvres:hasSeqnum ?seqnum .
+  ?fac knora-api:hasStillImageFileValue ?imageURL .
+}
+OFFSET ${index}
+`
+;
+  return this.knoraApiConnection.v2.search
+    .doExtendedSearch(gravsearchQuery)
+    .pipe(
+      map((
+        readResources: ReadResource[] 
+      ) => readResources.map(r => {
+          return this.readRes2Page(r);
+        })
+      )
+    );
+}
+
 
   getPersonLights(index: number = 0): Observable<PersonLight[]> {
     const gravsearchQuery = `
@@ -133,7 +167,23 @@ OFFSET ${index}
     } as Resource;
   }
 
-  readRes2PersonLight(readResource: ReadResource): PersonLight {
+  readRes2Page(readResource: ReadResource): Page {  
+    return {
+      ...this.readRes2Resource(readResource),
+      seqnum: this.getFirstValueAsStringOrNullOfProperty(
+        readResource,
+        `${this.getOntoPrefixPath()}hasSeqnum`
+      ),
+      imageURL: this.getFirstValueAsStringOrNullOfProperty(
+        readResource,
+        `http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue`
+      )
+    } as Page;   
+  }
+
+
+
+  readRes2PersonLight(readResource: ReadResource): PersonLight {  //this will populate PersonLight, following indications in the interface in person.mmodel.ts
     return {
       ...this.readRes2Resource(readResource),
       surname: this.getFirstValueAsStringOrNullOfProperty(
@@ -144,12 +194,12 @@ OFFSET ${index}
         readResource,
         `${this.getOntoPrefixPath()}personHasGivenName`
       )
-    } as PersonLight;
+    } as PersonLight;    //this indicates the interface declared in person.model.ts
   }
 
   readRes2Person(readResource: ReadResource): Person {
     return {
-      ...this.readRes2PersonLight(readResource),
+      ...this.readRes2PersonLight(readResource),  // person includes PersonLight's attributes
       dateOfBirth: this.getFirstValueAsStringOrNullOfProperty(
         readResource,
         `${this.getOntoPrefixPath()}hasBirthDate`
@@ -190,10 +240,7 @@ OFFSET ${index}
         readResource,
         `${this.getOntoPrefixPath()}hasTextContent`
       )
-      // imageURL: this.getFirstValueAsStringOrNullOfProperty(
-      //   readResource,
-      //   `http://api.knora.org/ontology/knora-api/v2#hasStillImageFileValue`
-      // )
+     
     } as Text;
   }
 


### PR DESCRIPTION
**Mapping updated**: it creates links inside the graph, fixed attributes of `<pb>` (only `@n`, the rest is taken from db).

**XSLTransformation added**. Name of original TEI elements are kept using `<span tei="nameOfTeiElement">` for every transformation, in order not to lose this info which can be useful for example to extract all persons, etc. 

**Todo**: decide what to put in XSLTransformation for `<pb>`, at the moment it creates an `<a>` with `@href` that retrieves the value of attribute `@n` (corresponding to values of `roud-oeuvres:hasSeqnum`). Goal is going to the corresponding page.

Problem now is that I've somehow broken the comboBox with list of images, @gfoo . Console.log says that the IRI of the text is there (of course, otherwise it could not visualize it), but imagesURL are gone ... The only thing I've changed is adding `ORDER BY ?seqnum`, but I tested afterwards and it worked. It stopped working when I added the XSLTransformation.

I send you updated data and onto, @gfoo .