### PR TITLE
adding overall control access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,3 +15,4 @@ FROM nginx:alpine
 COPY --from=builder /app/dist/oeuvres-roud-app/* /usr/share/nginx/html/
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY pwd_file /etc/apache2/.htpasswd

--- a/nginx.conf
+++ b/nginx.conf
@@ -7,6 +7,8 @@ server {
     absolute_redirect off;
 
     location / {
+	auth_basic "Accès pour l'équipe de recherche";
+	auth_basic_user_file /etc/apache2/.htpasswd;
 
         try_files $uri $uri/ /index.html;
 


### PR DESCRIPTION
adding a control access by pwd

you can reverting the file nginx.conf (removing the two `auth_basic`) and releasing.

or from the server:
```bash
# copy the file locally (from the container)
sudo podman cp roud:/etc/nginx/conf.d/default.conf .
# edit the file, remove the lines
sudo vi default.conf
# copy the file back to the container
sudo podman cp default.conf roud:/etc/nginx/conf.d/default.conf 
# restart
sudo podman restart roud
```