### PR TITLE
removing pubPart from request

### DIFF
--- a/src/app/services/data.service.ts
+++ b/src/app/services/data.service.ts
@@ -1786,7 +1786,6 @@ CONSTRUCT {
   ?pub knora-api:isMainResource true .
   ?pub roud-oeuvres:publicationHasTitle ?title .
   ?pub roud-oeuvres:publicationHasDate ?date .
-  ?pubPart roud-oeuvres:pubPartIsPartOf ?pub .
 } WHERE {
   ?pub a roud-oeuvres:Publication .
   ?pub roud-oeuvres:publicationHasTitle ?title .


### PR DESCRIPTION
The call to `getPublicationsWithThisAvantTexte` fails because of `pubPart` not being known to gravsearch.

This makes the publication not to be found.